### PR TITLE
Also delete key from cache if it not used before

### DIFF
--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -103,7 +103,7 @@ class ConfigLoader implements \ArrayAccess
 
         // check if in cache
         if (null !== $this->cache) {
-            $cacheKey = 'conf:'.abs(crc32($file));
+            $cacheKey = $this->getCacheKeyForFile($file);
             $conf = $this->app[$this->cache]->get($cacheKey);
             if (false !== $conf) {
                 $this->config[$key] = array(
@@ -283,6 +283,9 @@ class ConfigLoader implements \ArrayAccess
             }
 
             unset($this->config[$key]);
+        }else{
+            $file = $this->getFileNameForKey($key);
+            $this->app[$this->cache]->delete($this->getCacheKeyForFile($file));
         }
     }
 
@@ -344,6 +347,16 @@ class ConfigLoader implements \ArrayAccess
     public function offsetUnset($offset)
     {
         throw new \BadMethodCallException('"offsetUnset" is not supported.');
+    }
+
+    /**
+     * @param string $file
+     *
+     * @return string
+     */
+    private function getCacheKeyForFile($file)
+    {
+        return 'conf:'.abs(crc32($file));
     }
 
     /**


### PR DESCRIPTION
How about this? 

One test more fails that is the test where you flush an unknown item..

(other one was already failing).. 

```
$ phpunit
PHPUnit 5.3.2 by Sebastian Bergmann and contributors.

.......E...E.............                                         25 / 25 (100%)

Time: 231 ms, Memory: 10.00Mb

There were 2 errors:

1) GeckoPackages\Silex\Services\Config\Tests\ConfigServiceProviderTest::testCacheFlush
Symfony\Component\Filesystem\Exception\FileNotFoundException: Config "__DIR__" is not a directory.

/vagrant/vendor/gecko-packages/gecko-silex-config-service/src/Config/ConfigLoader.php:163
/vagrant/vendor/gecko-packages/gecko-silex-config-service/src/Config/ConfigLoader.php:77
/vagrant/vendor/gecko-packages/gecko-silex-config-service/tests/Config/Tests/ConfigServiceProviderTest.php:72

2) GeckoPackages\Silex\Services\Config\Tests\ConfigServiceProviderTest::testJSONConfig
InvalidArgumentException: Identifier "" is not defined.

/vagrant/vendor/gecko-packages/gecko-silex-config-service/vendor/pimple/pimple/lib/Pimple.php:78
/vagrant/vendor/gecko-packages/gecko-silex-config-service/src/Config/ConfigLoader.php:288
/vagrant/vendor/gecko-packages/gecko-silex-config-service/tests/Config/Tests/ConfigServiceProviderTest.php:187

FAILURES!
Tests: 25, Assertions: 109, Errors: 2.

```